### PR TITLE
Feat/gateway/issue2

### DIFF
--- a/devsta-gateway/pom.xml
+++ b/devsta-gateway/pom.xml
@@ -28,10 +28,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 public enum CommonCode {
     // SUCCESS
     SUCCESS(200, 200, "성공"),
+    OAUTH_CHECK_SUCCESS(200, 201, "Oauth 로그인 확인"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
 

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
@@ -21,8 +21,11 @@ public enum CommonCode {
     WRONG_PASSWORD(400, -1001, "비밀번호가 일치하지 않습니다."),
     USER_ALREADY_EXIST(400, -1002, "해당 아이디가 이미 존재합니다."),
     NICKNAME_ALREADY_EXIT(400, -1003 , "중복된 닉네임입니다." ),
-    NO_AUTH_TOKEN(400, -1004, "헤더에 Authorization 토큰이 없습니다."),
-    INVALID_AUTH_TOKEN(400, -1005, "Authorization 토큰이 유효하지 않습니다.");
+    INVALID_SOCIAL_LOGIN_TYPE(200, -1004, "알 수 없는 소셜 로그인 형식입니다."),
+    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다."),
+    INVALID_ELEMENTS(200, -1006, "조건에 맞지 않는 요소(elements)가 있습니다"),
+    NO_AUTH_TOKEN(400, -1007, "헤더에 Authorization 토큰이 없습니다."),
+    INVALID_AUTH_TOKEN(400, -1008, "Authorization 토큰이 유효하지 않습니다.");
 
 
     //-2000: MeetUp

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
@@ -15,6 +15,7 @@ public enum CommonCode {
     OAUTH_CHECK_SUCCESS(200, 201, "Oauth 로그인 확인"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
+    INVALID_ELEMENTS(400, -2, "조건에 맞지 않는 요소(elements)가 있습니다"),
 
     //-1000: USER
     NOT_EXIST_ID(400,-1000, "존재하지 않는 이메일입니다."),
@@ -23,7 +24,6 @@ public enum CommonCode {
     NICKNAME_ALREADY_EXIT(400, -1003 , "중복된 닉네임입니다." ),
     INVALID_SOCIAL_LOGIN_TYPE(200, -1004, "알 수 없는 소셜 로그인 형식입니다."),
     OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다."),
-    INVALID_ELEMENTS(200, -1006, "조건에 맞지 않는 요소(elements)가 있습니다"),
     NO_AUTH_TOKEN(400, -1007, "헤더에 Authorization 토큰이 없습니다."),
     INVALID_AUTH_TOKEN(400, -1008, "Authorization 토큰이 유효하지 않습니다.");
 

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonCode.java
@@ -20,7 +20,10 @@ public enum CommonCode {
     NOT_EXIST_ID(400,-1000, "존재하지 않는 이메일입니다."),
     WRONG_PASSWORD(400, -1001, "비밀번호가 일치하지 않습니다."),
     USER_ALREADY_EXIST(400, -1002, "해당 아이디가 이미 존재합니다."),
-    NICKNAME_ALREADY_EXIT(400, -1003 , "중복된 닉네임입니다." );
+    NICKNAME_ALREADY_EXIT(400, -1003 , "중복된 닉네임입니다." ),
+    NO_AUTH_TOKEN(400, -1004, "헤더에 Authorization 토큰이 없습니다."),
+    INVALID_AUTH_TOKEN(400, -1005, "Authorization 토큰이 유효하지 않습니다.");
+
 
     //-2000: MeetUp
 

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonResponse.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/CommonResponse.java
@@ -21,4 +21,10 @@ public class CommonResponse<T> {
         this.message = commonCode.getMessage();
     }
 
+    public CommonResponse(CommonCode commonCode, String message, Map<String, T> attribute) {
+        this.code = commonCode.getCode();
+        this.message = message;
+        this.attribute = attribute;
+    }
+
 }

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/ErrorControllerAdvice.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/ErrorControllerAdvice.java
@@ -12,6 +12,7 @@ import java.util.NoSuchElementException;
 @Slf4j
 public class ErrorControllerAdvice {
 
+    //CommonCode에 명시된 에러
     @ExceptionHandler(value = CustomException.class)
     protected ResponseEntity<CommonResponse<String>> handleCustomException(CustomException e) {
 //        ErrorResponse response = ErrorResponse.of(e.getErrorCode());
@@ -25,7 +26,15 @@ public class ErrorControllerAdvice {
 
     @ExceptionHandler(value = NoSuchElementException.class)
     protected ResponseEntity<CommonResponse<String>> handleNoSuchElementException(Exception e) {
-        CommonResponse<String> response= new CommonResponse(CommonCode.FAIL);
+        CommonResponse<String> response= new CommonResponse(CommonCode.FAIL, e.getMessage(), null);
+        log.error(e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    // CommonCode에 명시되지 않은 Exception 발생시 처리
+    @ExceptionHandler(value = UndefiedException.class)
+    protected ResponseEntity<CommonResponse<String>> handleUnDefinedExceptionHandler(Exception e) {
+        CommonResponse<String> response= new CommonResponse(CommonCode.FAIL, e.getMessage(), null);
         log.error(e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/common/UndefiedException.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/common/UndefiedException.java
@@ -1,0 +1,10 @@
+package com.moondysmell.gateway.common;
+
+//CommonCode에 명시되지 않은 Error. CustomException으로 처리할 수 없다.
+public class UndefiedException extends RuntimeException {
+
+    public UndefiedException(String message) {
+        super(message);
+    }
+
+}

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/config/RestClient.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/config/RestClient.java
@@ -32,20 +32,20 @@ public class RestClient{
         }
     }
 
-//    public String restTemplateGet(String serviceName, String endpoint, HashMap<String, ?> requestBody) {
-//        try {
-//            String serviceUrl = String.format("%s%s", serviceName, endpoint);
-//            HttpHeaders httpHeaders = new HttpHeaders();
-//            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-//            HttpEntity httpEntity = new HttpEntity(requestBody, httpHeaders);
-//            log.info("restTemplate -> $serviceUrl");
-//            ResponseEntity<String> restExchange = restTemplate.exchange(serviceUrl, HttpMethod.GET, httpEntity, String.class, "");
-//            log.info("restExchange -> $restExchange");
-//            log.info("body -> ${restExchange.body}");
-//            return restExchange.getBody();
-//        } catch (Exception e) {
-//            log.info(">>> " + e);
-//            return null;
-//        }
-//    }
+    public String restTemplateGet(String serviceName, String endpoint, HashMap<String, ?> requestBody) {
+        try {
+            String serviceUrl = String.format("%s%s", serviceName, endpoint);
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity httpEntity = new HttpEntity(requestBody, httpHeaders);
+            log.info("restTemplate -> " + serviceUrl);
+            ResponseEntity<String> restExchange = restTemplate.exchange(serviceUrl, HttpMethod.GET, httpEntity, String.class, "");
+            log.info("restExchange -> " + restExchange);
+            log.info("body -> " + restExchange.getBody());
+            return restExchange.getBody();
+        } catch (Exception e) {
+            log.info(">>> " + e);
+            return null;
+        }
+    }
 }

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/config/RestClient.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/config/RestClient.java
@@ -1,7 +1,6 @@
 package com.moondysmell.gateway.config;
 
-import com.moondysmell.gateway.common.CommonCode;
-import com.moondysmell.gateway.common.CustomException;
+import com.moondysmell.gateway.common.UndefiedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -27,8 +26,9 @@ public class RestClient{
             log.info("body -> " + restExchange.getBody());
             return restExchange.getBody();
         } catch (Exception e) {
+            //status 200이 아닌 에러메세지들은 여기로
             log.info(">>> " + e);
-            throw new CustomException(CommonCode.FAIL);
+            throw new UndefiedException(e.getMessage());
         }
     }
 
@@ -44,8 +44,9 @@ public class RestClient{
             log.info("body -> " + restExchange.getBody());
             return restExchange.getBody();
         } catch (Exception e) {
+            //status 200이 아닌 에러메세지들은 여기로
             log.info(">>> " + e);
-            return null;
+            throw new UndefiedException(e.getMessage());
         }
     }
 }

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/controller/AuthController.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/controller/AuthController.java
@@ -6,15 +6,14 @@ import com.moondysmell.gateway.common.CommonResponse;
 import com.moondysmell.gateway.config.RestClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestController
+@CrossOrigin(origins = "http://localhost:3000", maxAge = 3600)
 @RequestMapping("/api/auth")
 public class AuthController {
     private final RestClient restClient;
@@ -22,6 +21,7 @@ public class AuthController {
     public static final String SIGN_IN = "signIn";
     public static final String SIGN_UP = "signUp";
     public static final String CHANGE_PW = "changePw";
+    public static final String OAUTH = "oauth";
 
 
     @Value("${uri.user-service}")
@@ -51,5 +51,13 @@ public class AuthController {
         HashMap responseEntity;
         String response = restClient.restTemplatePost(userUri, "/auth/changePW", requestBody);
         return authService.parseResponseWrapper(response, CHANGE_PW);
+    }
+
+
+    @GetMapping("/oauth/{socialLoginType}")
+    public CommonResponse accessOauth(@PathVariable("socialLoginType") String oauthType, @RequestParam("code") String code) {
+        String response = restClient.restTemplateGet(userUri, String.format("/auth/oauth/%s?code=%s", oauthType, code),null);
+
+        return authService.parseResponseWrapper(response, OAUTH);
     }
 }

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/filter/UserJwtFilter.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/filter/UserJwtFilter.java
@@ -37,11 +37,6 @@ public class UserJwtFilter extends AbstractGatewayFilterFactory<UserJwtFilter.Co
         this.mapper = mapper;
     }
 
-//    @Override
-//    public List<String> shortcutFieldOrder() {
-//        return Collections.singletonList(ROLE_KEY);
-//    }
-
     @Override
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
@@ -70,10 +65,6 @@ public class UserJwtFilter extends AbstractGatewayFilterFactory<UserJwtFilter.Co
     private String extractToken(ServerHttpRequest request) {
         return request.getHeaders().getOrEmpty(HttpHeaders.AUTHORIZATION).get(0);
     }
-
-//    private boolean hasRole(TokenUser tokenUser, String role) {
-//        return role.equals(tokenUser.getRole());
-//    }
 
     private void addAuthorizationHeaders(ServerHttpRequest request, TokenUser tokenUser) {
         request.mutate()

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/filter/UserJwtFilter.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/filter/UserJwtFilter.java
@@ -1,7 +1,11 @@
 package com.moondysmell.gateway.filter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moondysmell.gateway.auth.JwtUtils;
 import com.moondysmell.gateway.auth.TokenUser;
+import com.moondysmell.gateway.common.CommonCode;
+import com.moondysmell.gateway.common.CommonResponse;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -15,6 +19,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 
 @Component
 @Slf4j
@@ -23,12 +28,13 @@ public class UserJwtFilter extends AbstractGatewayFilterFactory<UserJwtFilter.Co
 //    private static final String ROLE_KEY = "role";
     private static final String USER_ID = "userId";
     private static final String EMAIL = "email";
-
+    private ObjectMapper mapper;
     private final JwtUtils jwtUtils;
 
-    public UserJwtFilter(JwtUtils jwtUtils) {
+    public UserJwtFilter(JwtUtils jwtUtils, ObjectMapper mapper) {
         super(Config.class);
         this.jwtUtils = jwtUtils;
+        this.mapper = mapper;
     }
 
 //    @Override
@@ -43,12 +49,12 @@ public class UserJwtFilter extends AbstractGatewayFilterFactory<UserJwtFilter.Co
             ServerHttpResponse response = exchange.getResponse();
 
             if (!containsAuthorization(request)) {
-                return onError(response, "헤더에 Authorization 토큰이 없습니다.", HttpStatus.BAD_REQUEST);
+                return onError(response, new CommonResponse(CommonCode.NO_AUTH_TOKEN), HttpStatus.BAD_REQUEST);
             }
 
             String token = extractToken(request);
             if (!jwtUtils.isValid(token)) {
-                return onError(response, "Authorization 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+                return onError(response, new CommonResponse(CommonCode.INVALID_AUTH_TOKEN), HttpStatus.BAD_REQUEST);
             }
 
             TokenUser tokenUser = jwtUtils.decode(token);
@@ -76,9 +82,15 @@ public class UserJwtFilter extends AbstractGatewayFilterFactory<UserJwtFilter.Co
             .build();
     }
 
-    private Mono<Void> onError(ServerHttpResponse response, String message, HttpStatus status) {
+    private Mono<Void> onError(ServerHttpResponse response, CommonResponse commonCode, HttpStatus status) {
         response.setStatusCode(status);
-        DataBuffer buffer = response.bufferFactory().wrap(message.getBytes(StandardCharsets.UTF_8));
+        String msg;
+        try {
+            msg = mapper.writeValueAsString(commonCode);
+        } catch (JsonProcessingException e) {
+            msg = commonCode.getMessage();
+        }
+        DataBuffer buffer = response.bufferFactory().wrap(msg.getBytes(StandardCharsets.UTF_8));
         return response.writeWith(Mono.just(buffer));
     }
 

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/service/AuthService.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/service/AuthService.java
@@ -31,10 +31,15 @@ public class AuthService {
             switch (code) {
                 case 200:
                     switch (uri) {
-                        case SIGN_IN: return parseSignInSuccess(responseEntity);
+                        case SIGN_IN:
+                        case OAUTH:
+                            return parseSignInSuccess(responseEntity);
                         case SIGN_UP: return parseSignUpSuccess(responseEntity);
                         default: return parseChangePwSuccess(responseEntity);
                     }
+                case 201:
+                    log.info("oauthCheckSuccess >>> " + responseEntity);
+                    return new CommonResponse(CommonCode.OAUTH_CHECK_SUCCESS, (LinkedTreeMap) responseEntity.get("attribute"));
                 default:
                     return new CommonResponse(CommonCode.of((code)));
             }
@@ -50,6 +55,7 @@ public class AuthService {
         String id = (String) attribute.get("id");
         String email = (String) attribute.get("email");
         String token = jwtUtils.generate(new TokenUser(id, email));
+        log.info("parseSignInSuccess >>> ", token);
         return new CommonResponse(CommonCode.SUCCESS, Map.of("Authorization", token));
     }
 

--- a/devsta-gateway/src/main/java/com/moondysmell/gateway/service/AuthService.java
+++ b/devsta-gateway/src/main/java/com/moondysmell/gateway/service/AuthService.java
@@ -41,7 +41,9 @@ public class AuthService {
                     log.info("oauthCheckSuccess >>> " + responseEntity);
                     return new CommonResponse(CommonCode.OAUTH_CHECK_SUCCESS, (LinkedTreeMap) responseEntity.get("attribute"));
                 default:
-                    return new CommonResponse(CommonCode.of((code)));
+                    //에러
+                    Map map = (Map) responseEntity.get("attribute");
+                    return new CommonResponse(CommonCode.of((code)),responseEntity.get("message").toString(), map);
             }
 
         } catch (Exception e) {

--- a/devsta-gateway/src/main/resources/application.yml
+++ b/devsta-gateway/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
   cloud:
     gateway:
       globalcors:
-        corsConfigurations:
+        cors-configurations:
           '[/**]':
             allowedOrigins: "*"
             allowedMethods:

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/common/CommonCode.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/common/CommonCode.java
@@ -11,6 +11,7 @@ public enum CommonCode {
     SUCCESS(200, 200, "성공"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
+    INVALID_ELEMENTS(400, -2, "조건에 맞지 않는 요소(elements)가 있습니다"),
 
     //-1000: USER
 

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/common/CommonResponse.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/common/CommonResponse.java
@@ -21,4 +21,9 @@ public class CommonResponse<T> {
         this.message = commonCode.getMessage();
     }
 
+    public CommonResponse(CommonCode commonCode, String message, Map<String, T> attribute) {
+        this.code = commonCode.getCode();
+        this.message = message;
+        this.attribute = attribute;
+    }
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/common/ErrorControllerAdvice.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/common/ErrorControllerAdvice.java
@@ -3,9 +3,11 @@ package com.moondy.devstameetup.common;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestControllerAdvice
@@ -28,5 +30,12 @@ public class ErrorControllerAdvice {
         CommonResponse<String> response= new CommonResponse(CommonCode.FAIL);
         log.error(e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+        log.error(e.getMessage());
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/common/ErrorControllerAdvice.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/common/ErrorControllerAdvice.java
@@ -3,12 +3,17 @@ package com.moondy.devstameetup.common;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @RestControllerAdvice
 @Slf4j
@@ -33,9 +38,19 @@ public class ErrorControllerAdvice {
     }
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(BindException e) {
         log.error(e.getMessage());
-        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            stringBuilder.append(fieldError.getField()).append(":");
+            stringBuilder.append(fieldError.getDefaultMessage());
+            stringBuilder.append("; ");
+        }
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, stringBuilder.toString(), Map.of("errorTrace", e.getMessage()));
+        // 400으로 리턴하면 gateway 에서 UndefiedException으로 처리, 200으로 리턴하면 CommonResponse 처리 (CommonResponse 형식 지켜야함)
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/document/MeetUp.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/document/MeetUp.java
@@ -8,6 +8,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @Document(collection = "MeetUp")
@@ -47,6 +49,12 @@ public class MeetUp {
     @Field("leader_id")
     private String leaderId;
 
+    @Field("created_dt")
+    private LocalDateTime createdDt;
+
+    @Field("updated_dt")
+    private LocalDateTime updatedDt;
+
     public MeetUpDto toDto() {
         return MeetUpDto.builder()
                 .id(this.id.toString())
@@ -59,6 +67,8 @@ public class MeetUp {
                 .isOpenYn(this.isOpenYn)
                 .isRecruiting(this.isRecruiting)
                 .leaderId(this.leaderId)
+                .createdDt(this.createdDt)
+                .updatedDt(this.updatedDt)
                 .build();
     }
 
@@ -73,8 +83,8 @@ public class MeetUp {
                 .isOpenYn(this.isOpenYn)
                 .isRecruiting(this.isRecruiting)
                 .leaderId(this.leaderId)
+                .createdDt(this.createdDt)
+                .updatedDt(this.updatedDt)
                 .build();
     }
-
-
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/CreateMeetUpDto.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/CreateMeetUpDto.java
@@ -6,6 +6,7 @@ import lombok.*;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -39,6 +40,8 @@ public class CreateMeetUpDto {
                 .isOpenYn(this.getIsOpenYn())
                 .isRecruiting(true)
                 .leaderId(userId)
+                .createdDt(LocalDateTime.now())
+                .updatedDt(LocalDateTime.now())
                 .build();
     }
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/MeetUpDto.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/MeetUpDto.java
@@ -8,6 +8,9 @@ import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @Data
@@ -25,6 +28,6 @@ public class MeetUpDto {
     private Boolean isOpenYn;
     private Boolean isRecruiting;
     private String leaderId;
-
-
+    private LocalDateTime createdDt;
+    private LocalDateTime updatedDt;
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/MeetUpSummaryDto.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/domain/dto/MeetUpSummaryDto.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.hateoas.RepresentationModel;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @Data
@@ -22,4 +24,6 @@ public class MeetUpSummaryDto extends RepresentationModel<MeetUpSummaryDto> {
     private Boolean isOpenYn;
     private Boolean isRecruiting;
     private String leaderId;
+    private LocalDateTime createdDt;
+    private LocalDateTime updatedDt;
 }

--- a/devsta-meetup/src/main/java/com/moondy/devstameetup/service/MeetUpService.java
+++ b/devsta-meetup/src/main/java/com/moondy/devstameetup/service/MeetUpService.java
@@ -21,6 +21,7 @@ import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -166,6 +167,7 @@ public class MeetUpService {
         update.set("maxPeople", dto.getMaxPeople());
         update.set("isOpenYn", dto.getIsOpenYn());
         update.set("isRecruiting", dto.getIsRecruiting());
+        update.set("updatedDt", LocalDateTime.now());
         return updateMember(query, update);
     }
 
@@ -189,10 +191,12 @@ public class MeetUpService {
             memberList.add(userId);
             query.addCriteria(Criteria.where("id").is(dto.getMeetUpId()));
             update.set("memberId", memberList);
+            update.set("updatedDt", LocalDateTime.now());
         } else {
             pendingList.add(userId);
             query.addCriteria(Criteria.where("id").is(dto.getMeetUpId()));
             update.set("pendingId", pendingList);
+            update.set("updatedDt", LocalDateTime.now());
         }
         return updateMember(query, update);
     }
@@ -215,6 +219,7 @@ public class MeetUpService {
         pendingList.remove(dto.getMemberId());
         update.set("memberId", memberList);
         update.set("pendingId", pendingList);
+        update.set("updatedDt", LocalDateTime.now());
         return updateMember(query, update);
     }
 
@@ -235,6 +240,7 @@ public class MeetUpService {
 
         update.set("memberId", memberList);
         update.set("pendingId", pendingList);
+        update.set("updatedDt", LocalDateTime.now());
         return updateMember(query, update);
     }
 
@@ -255,6 +261,7 @@ public class MeetUpService {
 
         update.set("memberId", memberList);
         update.set("pendingId", pendingList);
+        update.set("updatedDt", LocalDateTime.now());
         return updateMember(query, update);
     }
 

--- a/devsta-meetup/src/test/java/com/moondy/devstameetup/service/MeetUpServiceTest.java
+++ b/devsta-meetup/src/test/java/com/moondy/devstameetup/service/MeetUpServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,7 +23,7 @@ class MeetUpServiceTest {
         MongoTemplate mongoTemplate = Mockito.mock(MongoTemplate.class);
         MeetUpService meetUpService = new MeetUpService(meetUpCategoryRepository, meetUpRepository, mongoTemplate);
         ObjectId tempId = new ObjectId();
-        MeetUp newMeetUp = new MeetUp(tempId, "STUDY", "스터디 구합니다", "서울 스더티 구합니다", 5, null, null, true, true, null);
+        MeetUp newMeetUp = new MeetUp(tempId, "STUDY", "스터디 구합니다", "서울 스더티 구합니다", 5, null, null, true, true, null, LocalDateTime.now(), LocalDateTime.now());
         Mockito.when(meetUpRepository.save(Mockito.any(MeetUp.class)))
                 .thenAnswer(i -> i.getArguments()[0]);
         Mockito.when(meetUpRepository.findById(tempId.toString()))

--- a/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/CommonCode.java
+++ b/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/CommonCode.java
@@ -11,6 +11,7 @@ public enum CommonCode {
     SUCCESS(200, 200, "성공"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
+    INVALID_ELEMENTS(400, -2, "조건에 맞지 않는 요소(elements)가 있습니다"),
 
     //-1000: USER
 

--- a/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/CommonResponse.java
+++ b/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/CommonResponse.java
@@ -21,4 +21,9 @@ public class CommonResponse<T> {
         this.message = commonCode.getMessage();
     }
 
+    public CommonResponse(CommonCode commonCode, String message, Map<String, T> attribute) {
+        this.code = commonCode.getCode();
+        this.message = message;
+        this.attribute = attribute;
+    }
 }

--- a/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/ErrorControllerAdvice.java
+++ b/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/ErrorControllerAdvice.java
@@ -3,11 +3,16 @@ package com.moondysmell.devstaposts.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @RestControllerAdvice
 @Slf4j
@@ -23,9 +28,19 @@ public class ErrorControllerAdvice {
     }
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(BindException e) {
         log.error(e.getMessage());
-        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            stringBuilder.append(fieldError.getField()).append(":");
+            stringBuilder.append(fieldError.getDefaultMessage());
+            stringBuilder.append("; ");
+        }
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, stringBuilder.toString(), Map.of("errorTrace", e.getMessage()));
+        // 400으로 리턴하면 gateway 에서 UndefiedException으로 처리, 200으로 리턴하면 CommonResponse 처리 (CommonResponse 형식 지켜야함)
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/ErrorControllerAdvice.java
+++ b/devsta-posts/src/main/java/com/moondysmell/devstaposts/exception/ErrorControllerAdvice.java
@@ -1,9 +1,13 @@
 package com.moondysmell.devstaposts.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
 
 @RestControllerAdvice
 @Slf4j
@@ -16,5 +20,12 @@ public class ErrorControllerAdvice {
         log.error(">>> " + response);
         log.error(e.getMessage());
         return new ResponseEntity<>(response, e.getHttpStatus());
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+        log.error(e.getMessage());
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
@@ -12,6 +12,7 @@ public enum CommonCode {
     OAUTH_CHECK_SUCCESS(200, 201, "Oauth 로그인 확인"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
+    INVALID_ELEMENTS(400, -2, "조건에 맞지 않는 요소(elements)가 있습니다"),
 
     //-1000: USER
     NOT_EXIST_ID(200,-1000, "존재하지 않는 이메일입니다."),
@@ -19,8 +20,8 @@ public enum CommonCode {
     USER_ALREADY_EXIST(200, -1002, "해당 아이디가 이미 존재합니다."),
     NICKNAME_ALREADY_EXIST(200, -1003 , "중복된 닉네임입니다." ),
     INVALID_SOCIAL_LOGIN_TYPE(200, -1004, "알 수 없는 소셜 로그인 형식입니다."),
-    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다."),
-    INVALID_ELEMENTS(200, -1006, "조건에 맞지 않는 요소(elements)가 있습니다");
+    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다.");
+    ;
 
     //-2000: MeetUp
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public enum CommonCode {
     // SUCCESS
     SUCCESS(200, 200, "성공"),
+    OAUTH_CHECK_SUCCESS(200, 201, "Oauth 로그인 확인"),
     // FAIL
     FAIL(500, -1, "실패. 알 수 없는 오류"),
 
@@ -16,7 +17,9 @@ public enum CommonCode {
     NOT_EXIST_ID(200,-1000, "존재하지 않는 이메일입니다."),
     WRONG_PASSWORD(200, -1001, "비밀번호가 일치하지 않습니다."),
     USER_ALREADY_EXIST(200, -1002, "해당 아이디가 이미 존재합니다."),
-    NICKNAME_ALREADY_EXIST(200, -1003 , "중복된 닉네임입니다." );
+    NICKNAME_ALREADY_EXIST(200, -1003 , "중복된 닉네임입니다." ),
+    INVALID_SOCIAL_LOGIN_TYPE(200, -1004, "알 수 없는 소셜 로그인 형식입니다."),
+    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다.");
 
     //-2000: MeetUp
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonCode.java
@@ -19,7 +19,8 @@ public enum CommonCode {
     USER_ALREADY_EXIST(200, -1002, "해당 아이디가 이미 존재합니다."),
     NICKNAME_ALREADY_EXIST(200, -1003 , "중복된 닉네임입니다." ),
     INVALID_SOCIAL_LOGIN_TYPE(200, -1004, "알 수 없는 소셜 로그인 형식입니다."),
-    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다.");
+    OAUTH_LOGIN_FAILED(200, -1005, "Oauth에서 프로필 정보를 가져오는데 실패했습니다."),
+    INVALID_ELEMENTS(200, -1006, "조건에 맞지 않는 요소(elements)가 있습니다");
 
     //-2000: MeetUp
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonResponse.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/CommonResponse.java
@@ -21,4 +21,10 @@ public class CommonResponse<T> {
         this.message = commonCode.getMessage();
     }
 
+    public CommonResponse(CommonCode commonCode, String message, Map<String, T> attribute) {
+        this.code = commonCode.getCode();
+        this.message = message;
+        this.attribute = attribute;
+    }
+
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
@@ -3,9 +3,11 @@ package com.moondysmell.devstausers.common;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestControllerAdvice
@@ -24,9 +26,17 @@ public class ErrorControllerAdvice {
     }
 
     @ExceptionHandler(value = NoSuchElementException.class)
-    protected ResponseEntity<CommonResponse<String>> handleNoSuchElementException(Exception e) {
-        CommonResponse<String> response= new CommonResponse(CommonCode.FAIL);
+    protected ResponseEntity<String> handleNoSuchElementException(Exception e) {
         log.error(e.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        // 400으로 리턴하면 gateway의
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+        log.error(e.getMessage());
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @RestControllerAdvice
 @Slf4j
@@ -28,7 +30,7 @@ public class ErrorControllerAdvice {
     @ExceptionHandler(value = NoSuchElementException.class)
     protected ResponseEntity<String> handleNoSuchElementException(Exception e) {
         log.error(e.getMessage());
-        // 400으로 리턴하면 gateway의
+        // 400으로 리턴하면 gateway 에서 UndefiedException으로 처리, 200으로 리턴하면 CustomException으로 처리 (CommonResponse 형식 지켜야함)
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
@@ -3,6 +3,9 @@ package com.moondysmell.devstausers.common;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -30,21 +33,24 @@ public class ErrorControllerAdvice {
     @ExceptionHandler(value = NoSuchElementException.class)
     protected ResponseEntity<String> handleNoSuchElementException(Exception e) {
         log.error(e.getMessage());
-        // 400으로 리턴하면 gateway 에서 UndefiedException으로 처리, 200으로 리턴하면 CustomException으로 처리 (CommonResponse 형식 지켜야함)
+        // 400으로 리턴하면 gateway 에서 UndefiedException으로 처리, 200으로 리턴하면 CommonResponse 처리 (CommonResponse 형식 지켜야함)
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
+    protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(BindException e) {
         log.error(e.getMessage());
-        Pattern pattern = Pattern.compile("(?<=default message \\[)(.*?)(?=\\])");
-        Matcher matcher = pattern.matcher(e.getMessage());
-        String result = "";
-        while (matcher.find()) {
-            result += matcher.group() + ";";
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            stringBuilder.append(fieldError.getField()).append(":");
+            stringBuilder.append(fieldError.getDefaultMessage());
+            stringBuilder.append("; ");
         }
-        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, result, Map.of("errorTrace", e.getMessage()));
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, stringBuilder.toString(), Map.of("errorTrace", e.getMessage()));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/common/ErrorControllerAdvice.java
@@ -38,7 +38,13 @@ public class ErrorControllerAdvice {
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     protected ResponseEntity<CommonResponse<String>> handleMethodArgumentNotValidException(Exception e) {
         log.error(e.getMessage());
-        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, Map.of("errorTrace", e.getMessage()));
+        Pattern pattern = Pattern.compile("(?<=default message \\[)(.*?)(?=\\])");
+        Matcher matcher = pattern.matcher(e.getMessage());
+        String result = "";
+        while (matcher.find()) {
+            result += matcher.group() + ";";
+        }
+        CommonResponse<String> response= new CommonResponse(CommonCode.INVALID_ELEMENTS, result, Map.of("errorTrace", e.getMessage()));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/config/RestTemplateConfig.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/config/RestTemplateConfig.java
@@ -1,0 +1,18 @@
+package com.moondysmell.devstausers.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    //HTTP get,post 요청을 날릴때 일정한 형식에 맞춰주는 template
+    @Bean
+    public RestTemplate restTemplate() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(3000);
+        return new RestTemplate(factory);
+    }
+}

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
@@ -9,7 +9,9 @@ import com.moondysmell.devstausers.domain.dto.ChangePwDto;
 import com.moondysmell.devstausers.domain.dto.LoginDto;
 import com.moondysmell.devstausers.domain.dto.UserDetailDto;
 import com.moondysmell.devstausers.domain.dto.UserSummaryDto;
+import com.moondysmell.devstausers.domain.oauth.GetSocialOAuthRes;
 import com.moondysmell.devstausers.service.DevUserService;
+import com.moondysmell.devstausers.service.OAuthService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +26,7 @@ import java.util.Map;
 @RequestMapping("/auth")
 public class AuthController {
     private final DevUserService devUserService;
+    private final OAuthService oAuthService;
     private final String DEFAULT_PICTURE_URL = "https://toppng.com//public/uploads/preview/user-account-management-logo-user-icon-11562867145a56rus2zwu.png";
 
     @PostMapping("/signIn")
@@ -34,7 +37,24 @@ public class AuthController {
         attribute.put("id", user.getId().toString());
         attribute.put("nickname", user.getNickname().toString());
         attribute.put("email", user.getEmail());
-        return new CommonResponse<String>(CommonCode.SUCCESS, attribute);
+        return new CommonResponse(CommonCode.SUCCESS, attribute);
+    }
+
+    @GetMapping("/checkEmail")
+    public CommonResponse checkEmail(@RequestParam("email") String email) {
+        DevUser user = devUserService.findUserByEmail(email);
+        return new CommonResponse(CommonCode.SUCCESS, Map.of("isExist", user != null));
+    }
+    @GetMapping("/oauth/{socialLoginType}")
+    public CommonResponse accessOauth(@PathVariable("socialLoginType") String oauthType, @RequestParam("code") String code) {
+        GetSocialOAuthRes res = oAuthService.oAuthLogin(oauthType.toUpperCase(), code);
+        DevUser user = devUserService.findUserByEmail(res.getEmail());
+        if (user == null) {
+            return new CommonResponse(CommonCode.OAUTH_CHECK_SUCCESS, Map.of("userInfo", res));
+        } else {
+            // 유저가 이미 존재하는 경우 어떻게 Gateway에 데이터를 넘겨줄지에 따라 attribute 객체가 수정될 수 있음
+            return new CommonResponse(CommonCode.USER_ALREADY_EXIST, Map.of("userInfo", new GetSocialOAuthRes(user)));
+        }
     }
 
     @PostMapping("/changePW")

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
@@ -74,6 +74,9 @@ public class AuthController {
         if (userDetailDto.getPictureUrl() == null) {
             userDetailDto.setPictureUrl(DEFAULT_PICTURE_URL);
         }
+        if (userDetailDto.getProvider() == null) {
+            userDetailDto.setProvider("app");
+        }
         try {
             DevUser savedUser = devUserService.saveUser(userDetailDto);
             if (savedUser != null) return new CommonResponse(CommonCode.SUCCESS, Map.of("user", new UserSummaryDto(savedUser)));

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/controller/AuthController.java
@@ -78,18 +78,11 @@ public class AuthController {
             DevUser savedUser = devUserService.saveUser(userDetailDto);
             if (savedUser != null) return new CommonResponse(CommonCode.SUCCESS, Map.of("user", new UserSummaryDto(savedUser)));
             return new CommonResponse(CommonCode.FAIL);
-
         }catch (Exception e) {
             log.error(">>> " + e.getMessage());
             throw new CustomException(CommonCode.FAIL);
         }
-
-
     }
-
-
-
-
 
 }
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/document/DevUser.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/document/DevUser.java
@@ -52,6 +52,7 @@ public class DevUser {
     }
 
     public DevUser ofDetail(UserDetailDto userDetailDto) {
+        this.name = userDetailDto.getName();
         this.nickname = userDetailDto.getNickname();
         this.password = userDetailDto.getPassword();
         this.pictureUrl = userDetailDto.getPictureUrl();
@@ -61,7 +62,7 @@ public class DevUser {
         this.github = userDetailDto.getGithub();
         this.blog = userDetailDto.getBlog();
         this.tags = userDetailDto.getTags();
-        this.provider = "app";
+        this.provider = userDetailDto.getProvider();
         return this;
     }
 

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/dto/UserDetailDto.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/dto/UserDetailDto.java
@@ -1,9 +1,7 @@
 package com.moondysmell.devstausers.domain.dto;
 
 import com.moondysmell.devstausers.domain.document.DevUser;
-import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -17,6 +15,8 @@ import java.util.List;
 
 @Data
 @RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserDetailDto implements Serializable {
     @NotBlank
     private String name;
@@ -41,6 +41,4 @@ public class UserDetailDto implements Serializable {
     //Oauth를 위해 구성한 추가 필드
     @Field("provider")
     private String provider;
-
-
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/dto/UserSummaryDto.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/dto/UserSummaryDto.java
@@ -6,20 +6,35 @@ import lombok.Getter;
 
 
 import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
 
 @Data
 @Getter
 public class UserSummaryDto implements Serializable {
     private String id;
+    private String name;
     private String nickname;
     private String pictureUrl;
+    private Date createdDt;
+    private String description;
     private String email;
+    private String github;
+    private String blog;
+    private List<String> tags;
+    private String provider;
 
     public UserSummaryDto(DevUser devUser) {
         this.id = devUser.getId().toString();
+        this.name = devUser.getName();
         this.nickname = devUser.getNickname();
-        this.email = devUser.getEmail();
         this.pictureUrl = devUser.getPictureUrl();
+        this.createdDt = devUser.getCreatedDt();
+        this.description = devUser.getDescription();
+        this.email = devUser.getEmail();
+        this.github = devUser.getGithub();
+        this.blog = devUser.getBlog();
+        this.tags = devUser.getTags();
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GetSocialOAuthRes.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GetSocialOAuthRes.java
@@ -1,0 +1,23 @@
+package com.moondysmell.devstausers.domain.oauth;
+
+import com.moondysmell.devstausers.domain.document.DevUser;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetSocialOAuthRes {
+    String email;
+    String userName;
+    String pictureUrl;
+
+    public GetSocialOAuthRes(DevUser user) {
+        this.email = user.getEmail();
+        this.userName = user.getName();
+        this.pictureUrl = user.getPictureUrl();
+    }
+}

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOAuthToken.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOAuthToken.java
@@ -1,0 +1,17 @@
+package com.moondysmell.devstausers.domain.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+//구글에 일회성 코드를 다시 보내 받아올 액세스 토큰을 포함한 JSON 문자열을 담을 클래스
+@AllArgsConstructor
+@Getter
+@Setter
+public class GoogleOAuthToken {
+    private String access_token;
+    private int expires_in;
+    private String scope;
+    private String token_type;
+    private String id_token;
+}

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOauth.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOauth.java
@@ -1,0 +1,55 @@
+package com.moondysmell.devstausers.domain.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+//@AllArgsConstructor
+@Component
+@RequiredArgsConstructor
+public class GoogleOauth {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public GoogleOAuthToken getAccessToken(String code) throws JsonProcessingException {
+        GoogleOAuthToken googleOAuthToken = objectMapper.readValue(code, GoogleOAuthToken.class);
+        return googleOAuthToken;
+    }
+
+    public ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+        String GOOGLE_USERINFO_REQUEST_URL="https://www.googleapis.com/oauth2/v1/userinfo";
+
+        //header에 accessToken을 담는다.
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization","Bearer "+oAuthToken.getAccess_token());
+        System.out.println("Authorization: " + "Bearer "+oAuthToken.getAccess_token());
+
+        //HttpEntity를 하나 생성해 헤더를 담아서 restTemplate으로 구글과 통신하게 된다.
+        HttpEntity request = new HttpEntity(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GOOGLE_USERINFO_REQUEST_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        System.out.println("response.getBody() = " + response.getBody());
+        return response;
+    }
+
+    public GoogleUser getUserInfo(ResponseEntity<String> userInfoRes) throws JsonProcessingException {
+        GoogleUser googleUser = objectMapper.readValue(userInfoRes.getBody(), GoogleUser.class);
+        System.out.println(googleUser.toString());
+        return googleUser;
+    }
+}

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOauth.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleOauth.java
@@ -3,6 +3,7 @@ package com.moondysmell.devstausers.domain.oauth;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 //@AllArgsConstructor
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GoogleOauth {
 
     private final RestTemplate restTemplate;
@@ -25,13 +27,13 @@ public class GoogleOauth {
         return googleOAuthToken;
     }
 
-    public ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+    public ResponseEntity<String> requestUserInfo(String oAuthToken) {
         String GOOGLE_USERINFO_REQUEST_URL="https://www.googleapis.com/oauth2/v1/userinfo";
 
         //header에 accessToken을 담는다.
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization","Bearer "+oAuthToken.getAccess_token());
-        System.out.println("Authorization: " + "Bearer "+oAuthToken.getAccess_token());
+        headers.set("Authorization","Bearer "+oAuthToken);
+        log.info("Authorization: " + "Bearer "+oAuthToken);
 
         //HttpEntity를 하나 생성해 헤더를 담아서 restTemplate으로 구글과 통신하게 된다.
         HttpEntity request = new HttpEntity(headers);
@@ -43,13 +45,13 @@ public class GoogleOauth {
                 String.class
         );
 
-        System.out.println("response.getBody() = " + response.getBody());
+        log.info("response.getBody() = " + response.getBody());
         return response;
     }
 
     public GoogleUser getUserInfo(ResponseEntity<String> userInfoRes) throws JsonProcessingException {
         GoogleUser googleUser = objectMapper.readValue(userInfoRes.getBody(), GoogleUser.class);
-        System.out.println(googleUser.toString());
+        log.info(googleUser.toString());
         return googleUser;
     }
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleUser.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/domain/oauth/GoogleUser.java
@@ -1,0 +1,20 @@
+package com.moondysmell.devstausers.domain.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+//구글(서드파티)로 액세스 토큰을 보내 받아올 구글에 등록된 사용자 정보
+@AllArgsConstructor
+@Getter
+@Setter
+public class GoogleUser {
+    public String id;
+    public String email;
+    public Boolean verifiedEmail;
+    public String name;
+    public String givenName;
+    public String familyName;
+    public String picture;
+    public String locale;
+}

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/service/DevUserService.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/service/DevUserService.java
@@ -22,7 +22,6 @@ import java.util.NoSuchElementException;
 public class DevUserService {
     private final DevUserRepository devUserRepository;
     private final MongoTemplate mongoTemplate;
-
     final static private String COLLECTION_NAME = "DevUser";
 
     public DevUser findUserByEmail(String email) {
@@ -82,6 +81,5 @@ public class DevUserService {
         }
         return devUserRepository.save(updateUser);
     }
-
 
 }

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/service/OAuthService.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/service/OAuthService.java
@@ -25,9 +25,9 @@ public class OAuthService {
             case "GOOGLE": {
                 try {
                     //응답 객체가 JSON형식으로 되어 있으므로, 이를 deserialization해서 자바 객체에 담을 것이다.
-                    GoogleOAuthToken oAuthToken = googleOauth.getAccessToken(code);
+//                    GoogleOAuthToken oAuthToken = googleOauth.getAccessToken(code);
                     //액세스 토큰을 다시 구글로 보내 구글에 저장된 사용자 정보가 담긴 응답 객체를 받아온다.
-                    ResponseEntity<String> userInfoResponse = googleOauth.requestUserInfo(oAuthToken);
+                    ResponseEntity<String> userInfoResponse = googleOauth.requestUserInfo(code);
                     //다시 JSON 형식의 응답 객체를 자바 객체로 역직렬화한다.
                     GoogleUser googleUser = googleOauth.getUserInfo(userInfoResponse);
                     log.info("googleUser: " + googleUser.getEmail());

--- a/devsta-users/src/main/java/com/moondysmell/devstausers/service/OAuthService.java
+++ b/devsta-users/src/main/java/com/moondysmell/devstausers/service/OAuthService.java
@@ -1,0 +1,48 @@
+package com.moondysmell.devstausers.service;
+
+import com.moondysmell.devstausers.common.CommonCode;
+import com.moondysmell.devstausers.common.CustomException;
+import com.moondysmell.devstausers.domain.oauth.GetSocialOAuthRes;
+import com.moondysmell.devstausers.domain.oauth.GoogleOAuthToken;
+import com.moondysmell.devstausers.domain.oauth.GoogleOauth;
+import com.moondysmell.devstausers.domain.oauth.GoogleUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthService {
+    private final GoogleOauth googleOauth;
+
+    public GetSocialOAuthRes oAuthLogin(String socialLoginType, String code) throws CustomException {
+        GetSocialOAuthRes result;
+        switch (socialLoginType) {
+            case "GOOGLE": {
+                try {
+                    //응답 객체가 JSON형식으로 되어 있으므로, 이를 deserialization해서 자바 객체에 담을 것이다.
+                    GoogleOAuthToken oAuthToken = googleOauth.getAccessToken(code);
+                    //액세스 토큰을 다시 구글로 보내 구글에 저장된 사용자 정보가 담긴 응답 객체를 받아온다.
+                    ResponseEntity<String> userInfoResponse = googleOauth.requestUserInfo(oAuthToken);
+                    //다시 JSON 형식의 응답 객체를 자바 객체로 역직렬화한다.
+                    GoogleUser googleUser = googleOauth.getUserInfo(userInfoResponse);
+                    log.info("googleUser: " + googleUser.getEmail());
+                    result = new GetSocialOAuthRes(googleUser.email, googleUser.name, googleUser.getPicture());
+                    break;
+                } catch (Exception e) {
+                    log.error(">>>" + e.getMessage());
+                    throw new CustomException(CommonCode.OAUTH_LOGIN_FAILED);
+                }
+
+            }
+            default: {
+                throw new CustomException(CommonCode.INVALID_SOCIAL_LOGIN_TYPE);
+            }
+        }
+        return result;
+    }
+}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/DevUserServiceTest.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/DevUserServiceTest.java
@@ -1,141 +1,141 @@
-package com.moondysmell.devstausers.service;
-
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import com.moondysmell.devstausers.domain.document.DevUser;
-import com.moondysmell.devstausers.domain.dto.UserDetailDto;
-import com.moondysmell.devstausers.repository.DevUserRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-
-import java.util.Date;
-import java.util.List;
-import static org.junit.jupiter.api.Assertions.*;
-
-@ExtendWith(MockitoExtension.class)
-@SpringJUnitConfig(TestConfig.class)
-@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
-@EnableAutoConfiguration
-@DataMongoTest
-class DevUserServiceTest {
-
-    @InjectMocks
-    private DevUserService userService;
-
-    @MockBean
-    private DevUserRepository devUserRepository;
-
-    @Autowired
-    @Qualifier("testMongoTemplate")
-    private MongoTemplate mongoTemplate;
-
-
-    DevUserServiceTest() {
-    }
-
-    @Test
-    @DisplayName("mongoTemplate 커넥션 확인(find 쿼리)")
-    public void findOneTest() {
-        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
-        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
-        Assertions.assertEquals(1, target.size());
-        Assertions.assertEquals("김모모", target.get(0).getName());
-    }
-
-    @Test
-    @DisplayName("mongoTemplate insert 테스트")
-    public void insertTest() {
-        UserDetailDto dto = UserDetailDto.builder()
-                .name("kiki")
-                .nickname("kiki")
-                .password("kiki1234")
-                .pictureUrl(null)
-                .createdDt(null)
-                .description(null)
-                .email("kiki@gmail.com")
-                .github(null)
-                .blog(null)
-                .tags(null)
-                .provider("app")
-                .build();
-        DevUser newUser = new DevUser();
-        newUser.ofDetail(dto);
-        DevUser savedUser = mongoTemplate.insert(newUser, "DevUser");
-
-        Query query = new Query(Criteria.where("email").is("kiki@gmail.com"));
-        DevUser target = mongoTemplate.findOne(query, DevUser.class);
-        Assertions.assertEquals(dto.getName(), target.getName());
-
-
-    }
-
-    @Test
-    void findUserByEmail() {
-//        //given
-//        DevUser devUser = DevUser.builder()
-//                .name("mock유저1")
-//                .age(20)
-//                .build();
-//        List<Member> members = new ArrayList<>();
-//        members.add(member1);
+//package com.moondysmell.devstausers.service;
 //
-//        given(memberRepository.findAll()).willReturn(members);
-
-        //given
-        String targetEmail = "momo@gmail.com";
-        DevUser result = userService.findUserByEmail(targetEmail);
-        assertEquals(targetEmail, result.getEmail());
-        assertEquals("김모모", result.getName());
-    }
-
-
-    @Test
-    void checkExistUser() {
-//        Query query = new Query(Criteria.where("email").is("dada@gmail.com"));
-//        DevUser targetUser = mongoTemplateLocal.findOne(query, DevUser.class);
-
-    }
-
-    @Test
-    void findAllUserByEmail() {
-    }
-
-    @Test
-    void findAllUserByNickname() {
-    }
-
-    @Test
-    void findUserById() {
-    }
-
-    @Test
-    void findAll() {
-    }
-
-    @Test
-    void updatePw() {
-    }
-
-    @Test
-    void saveUser() {
-    }
-
-    @Test
-    void updateProfile() {
-    }
-}
+//import com.mongodb.client.MongoClient;
+//import com.mongodb.client.MongoClients;
+//import com.moondysmell.devstausers.domain.document.DevUser;
+//import com.moondysmell.devstausers.domain.dto.UserDetailDto;
+//import com.moondysmell.devstausers.repository.DevUserRepository;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Qualifier;
+//import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+//import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.data.mongodb.core.MongoTemplate;
+//import org.springframework.data.mongodb.core.query.Criteria;
+//import org.springframework.data.mongodb.core.query.Query;
+//import org.springframework.test.context.TestPropertySource;
+//import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+//
+//import java.util.Date;
+//import java.util.List;
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//@ExtendWith(MockitoExtension.class)
+//@SpringJUnitConfig(TestConfig.class)
+//@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
+//@EnableAutoConfiguration
+//@DataMongoTest
+//class DevUserServiceTest {
+//
+//    @InjectMocks
+//    private DevUserService userService;
+//
+//    @MockBean
+//    private DevUserRepository devUserRepository;
+//
+//    @Autowired
+//    @Qualifier("testMongoTemplate")
+//    private MongoTemplate mongoTemplate;
+//
+//
+//    DevUserServiceTest() {
+//    }
+//
+//    @Test
+//    @DisplayName("mongoTemplate 커넥션 확인(find 쿼리)")
+//    public void findOneTest() {
+//        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
+//        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
+//        Assertions.assertEquals(1, target.size());
+//        Assertions.assertEquals("김모모", target.get(0).getName());
+//    }
+//
+//    @Test
+//    @DisplayName("mongoTemplate insert 테스트")
+//    public void insertTest() {
+//        UserDetailDto dto = UserDetailDto.builder()
+//                .name("kiki")
+//                .nickname("kiki")
+//                .password("kiki1234")
+//                .pictureUrl(null)
+//                .createdDt(null)
+//                .description(null)
+//                .email("kiki@gmail.com")
+//                .github(null)
+//                .blog(null)
+//                .tags(null)
+//                .provider("app")
+//                .build();
+//        DevUser newUser = new DevUser();
+//        newUser.ofDetail(dto);
+//        DevUser savedUser = mongoTemplate.insert(newUser, "DevUser");
+//
+//        Query query = new Query(Criteria.where("email").is("kiki@gmail.com"));
+//        DevUser target = mongoTemplate.findOne(query, DevUser.class);
+//        Assertions.assertEquals(dto.getName(), target.getName());
+//
+//
+//    }
+//
+////    @Test
+////    void findUserByEmail() {
+//////        //given
+//////        DevUser devUser = DevUser.builder()
+//////                .name("mock유저1")
+//////                .age(20)
+//////                .build();
+//////        List<Member> members = new ArrayList<>();
+//////        members.add(member1);
+//////
+//////        given(memberRepository.findAll()).willReturn(members);
+////
+////        //given
+////        String targetEmail = "momo@gmail.com";
+////        DevUser result = userService.findUserByEmail(targetEmail);
+////        assertEquals(targetEmail, result.getEmail());
+////        assertEquals("김모모", result.getName());
+////    }
+//
+//
+//    @Test
+//    void checkExistUser() {
+////        Query query = new Query(Criteria.where("email").is("dada@gmail.com"));
+////        DevUser targetUser = mongoTemplateLocal.findOne(query, DevUser.class);
+//
+//    }
+//
+//    @Test
+//    void findAllUserByEmail() {
+//    }
+//
+//    @Test
+//    void findAllUserByNickname() {
+//    }
+//
+//    @Test
+//    void findUserById() {
+//    }
+//
+//    @Test
+//    void findAll() {
+//    }
+//
+//    @Test
+//    void updatePw() {
+//    }
+//
+//    @Test
+//    void saveUser() {
+//    }
+//
+//    @Test
+//    void updateProfile() {
+//    }
+//}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/DevUserServiceTest.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/DevUserServiceTest.java
@@ -1,0 +1,141 @@
+package com.moondysmell.devstausers.service;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.moondysmell.devstausers.domain.document.DevUser;
+import com.moondysmell.devstausers.domain.dto.UserDetailDto;
+import com.moondysmell.devstausers.repository.DevUserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.Date;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@SpringJUnitConfig(TestConfig.class)
+@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
+@EnableAutoConfiguration
+@DataMongoTest
+class DevUserServiceTest {
+
+    @InjectMocks
+    private DevUserService userService;
+
+    @MockBean
+    private DevUserRepository devUserRepository;
+
+    @Autowired
+    @Qualifier("testMongoTemplate")
+    private MongoTemplate mongoTemplate;
+
+
+    DevUserServiceTest() {
+    }
+
+    @Test
+    @DisplayName("mongoTemplate 커넥션 확인(find 쿼리)")
+    public void findOneTest() {
+        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
+        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
+        Assertions.assertEquals(1, target.size());
+        Assertions.assertEquals("김모모", target.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("mongoTemplate insert 테스트")
+    public void insertTest() {
+        UserDetailDto dto = UserDetailDto.builder()
+                .name("kiki")
+                .nickname("kiki")
+                .password("kiki1234")
+                .pictureUrl(null)
+                .createdDt(null)
+                .description(null)
+                .email("kiki@gmail.com")
+                .github(null)
+                .blog(null)
+                .tags(null)
+                .provider("app")
+                .build();
+        DevUser newUser = new DevUser();
+        newUser.ofDetail(dto);
+        DevUser savedUser = mongoTemplate.insert(newUser, "DevUser");
+
+        Query query = new Query(Criteria.where("email").is("kiki@gmail.com"));
+        DevUser target = mongoTemplate.findOne(query, DevUser.class);
+        Assertions.assertEquals(dto.getName(), target.getName());
+
+
+    }
+
+    @Test
+    void findUserByEmail() {
+//        //given
+//        DevUser devUser = DevUser.builder()
+//                .name("mock유저1")
+//                .age(20)
+//                .build();
+//        List<Member> members = new ArrayList<>();
+//        members.add(member1);
+//
+//        given(memberRepository.findAll()).willReturn(members);
+
+        //given
+        String targetEmail = "momo@gmail.com";
+        DevUser result = userService.findUserByEmail(targetEmail);
+        assertEquals(targetEmail, result.getEmail());
+        assertEquals("김모모", result.getName());
+    }
+
+
+    @Test
+    void checkExistUser() {
+//        Query query = new Query(Criteria.where("email").is("dada@gmail.com"));
+//        DevUser targetUser = mongoTemplateLocal.findOne(query, DevUser.class);
+
+    }
+
+    @Test
+    void findAllUserByEmail() {
+    }
+
+    @Test
+    void findAllUserByNickname() {
+    }
+
+    @Test
+    void findUserById() {
+    }
+
+    @Test
+    void findAll() {
+    }
+
+    @Test
+    void updatePw() {
+    }
+
+    @Test
+    void saveUser() {
+    }
+
+    @Test
+    void updateProfile() {
+    }
+}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/MongoTest.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/MongoTest.java
@@ -1,36 +1,36 @@
-package com.moondysmell.devstausers.service;
-
-import com.moondysmell.devstausers.domain.document.DevUser;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-
-import java.util.List;
-
-@SpringJUnitConfig(TestConfig.class)
-@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
-@EnableAutoConfiguration
-@DataMongoTest
-public class MongoTest {
-    @Autowired
-    @Qualifier("testMongoTemplate")
-    private MongoTemplate mongoTemplate;
-
-    @Test
-    @DisplayName("mongoTemplate Custom 빈 등록")
-    public void findOneTest() {
-        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
-        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
-        Assertions.assertEquals(1, target.size());
-        Assertions.assertEquals("김모모", target.get(0).getName());
-    }
-}
+//package com.moondysmell.devstausers.service;
+//
+//import com.moondysmell.devstausers.domain.document.DevUser;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Qualifier;
+//import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+//import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+//import org.springframework.data.mongodb.core.MongoTemplate;
+//import org.springframework.data.mongodb.core.query.Criteria;
+//import org.springframework.data.mongodb.core.query.Query;
+//import org.springframework.test.context.TestPropertySource;
+//import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+//
+//import java.util.List;
+//
+//@SpringJUnitConfig(TestConfig.class)
+//@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
+//@EnableAutoConfiguration
+//@DataMongoTest
+//public class MongoTest {
+//    @Autowired
+//    @Qualifier("testMongoTemplate")
+//    private MongoTemplate mongoTemplate;
+//
+//    @Test
+//    @DisplayName("mongoTemplate Custom 빈 등록")
+//    public void findOneTest() {
+//        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
+//        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
+//        Assertions.assertEquals(1, target.size());
+//        Assertions.assertEquals("김모모", target.get(0).getName());
+//    }
+//}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/MongoTest.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/MongoTest.java
@@ -1,0 +1,36 @@
+package com.moondysmell.devstausers.service;
+
+import com.moondysmell.devstausers.domain.document.DevUser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.List;
+
+@SpringJUnitConfig(TestConfig.class)
+@TestPropertySource(properties = "spring.mongodb.embedded.version=3.5.5")
+@EnableAutoConfiguration
+@DataMongoTest
+public class MongoTest {
+    @Autowired
+    @Qualifier("testMongoTemplate")
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    @DisplayName("mongoTemplate Custom 빈 등록")
+    public void findOneTest() {
+        Query query = new Query(Criteria.where("email").is("momo@gmail.com"));
+        List<DevUser> target = mongoTemplate.find(query, DevUser.class);
+        Assertions.assertEquals(1, target.size());
+        Assertions.assertEquals("김모모", target.get(0).getName());
+    }
+}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/TestConfig.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/TestConfig.java
@@ -1,0 +1,24 @@
+package com.moondysmell.devstausers.service;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.validation.Valid;
+
+@Configuration(proxyBeanMethods = false)
+class TestConfig {
+
+  @Value("${spring.data.mongodb.uri}")
+  String mongoDBUrl = "";
+
+  @Bean("testMongoTemplate") // testMongoTemplate Bean 설정 및 선언하기
+  public MongoTemplate mongoTemplateConfig() {
+    MongoClient mongoClient = MongoClients.create(mongoDBUrl);
+    return new MongoTemplate(mongoClient, "devstagram");
+  }
+}

--- a/devsta-users/src/test/java/com/moondysmell/devstausers/service/TestConfig.java
+++ b/devsta-users/src/test/java/com/moondysmell/devstausers/service/TestConfig.java
@@ -1,24 +1,24 @@
-package com.moondysmell.devstausers.service;
-
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.context.ActiveProfiles;
-
-import javax.validation.Valid;
-
-@Configuration(proxyBeanMethods = false)
-class TestConfig {
-
-  @Value("${spring.data.mongodb.uri}")
-  String mongoDBUrl = "";
-
-  @Bean("testMongoTemplate") // testMongoTemplate Bean 설정 및 선언하기
-  public MongoTemplate mongoTemplateConfig() {
-    MongoClient mongoClient = MongoClients.create(mongoDBUrl);
-    return new MongoTemplate(mongoClient, "devstagram");
-  }
-}
+//package com.moondysmell.devstausers.service;
+//
+//import com.mongodb.client.MongoClient;
+//import com.mongodb.client.MongoClients;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.mongodb.core.MongoTemplate;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//import javax.validation.Valid;
+//
+//@Configuration(proxyBeanMethods = false)
+//class TestConfig {
+//
+//  @Value("${spring.data.mongodb.uri}")
+//  String mongoDBUrl = "";
+//
+//  @Bean("testMongoTemplate") // testMongoTemplate Bean 설정 및 선언하기
+//  public MongoTemplate mongoTemplateConfig() {
+//    MongoClient mongoClient = MongoClients.create(mongoDBUrl);
+//    return new MongoTemplate(mongoClient, "devstagram");
+//  }
+//}


### PR DESCRIPTION
# [gateway] CORS, JWT 에러 형식 통일

## 1. CORS

- 문제: signIn API 사용시 CORS 에러 (request from http://localhost:3000/)
- 원인
    - Spring Cloud Gateway의 Global Configuration으로는 CORS 설정이 되어있었지만, Auth Controller를 통해 요청되는 것들은 그 설정이 먹히지 않음
- 조치
    - AuthController만 내부통신 하기 때문에 AuthController에만 CORS 설정 따로 해줌
- 의견
    - CloudGateway와 Rest Controller의 설정이 달라서 관리 포인트가 2개가 된다는 단점과, 또다른 REST Controller가 생기면 똑같은 설정을 또 반복적으로 해줘야 한다는 단점
    - 하지만 현재는(앞으로의 계획에도) REST Controller가 1개뿐이기 때문에 Global Configuration을 따로 세팅해줘도 똑같은 효과가 나기 때문에 굳이 공수를 들이지 않아도 될 것 같다.
    - Global Configuration을 설정하기 위해서는 WebServlet역할을 하는 무언가를 더 설치하고 설정해야하는것 같다
    

## 2. JWT 에러 형식 통일하기

- 문제: 다른 API는 CommonResponse 형식으로 리턴되지만, JWT Filter 에러는 에러 메세지만 리턴되는 문제 ⇒ 통일 필요
- 조치
    - Gateway는 WebFlux 방식으로 통신하기 때문에 Response Entity로 리턴할 수 없음.
    - 따라서 CommonResponse → json → bytes → DataBuffer 로 변환하여 Body에 넣어 리턴